### PR TITLE
feat(mcp): CDP tools + full profile CRUD over MCP

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,7 +16,8 @@
     "build:win:publish": "electron-vite build && node ./scripts/strip-workspace-symlinks.cjs && electron-builder --win --publish always",
     "build:linux:publish": "electron-vite build && node ./scripts/strip-workspace-symlinks.cjs && electron-builder --linux --publish always",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "preview": "electron-vite preview"
+    "preview": "electron-vite preview",
+    "test": "node --import ../../packages/mcp-server/node_modules/tsx/dist/loader.mjs --test src/main/cdpReadiness.test.ts"
   },
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",

--- a/apps/desktop/src/main/ChromiumBrowserDriver.ts
+++ b/apps/desktop/src/main/ChromiumBrowserDriver.ts
@@ -13,6 +13,7 @@ import type { BrowserDriver } from "@multizen/mcp-server";
 import type { ProfileManager } from "@multizen/profile-manager";
 import { reconcileDeviceFamilyToHost } from "@multizen/profile-manager";
 import type { ClientHints, FingerprintConfig, LaunchedProfile, ProfileId } from "@multizen/types";
+import { waitForCdpSessionReady } from "./cdpReadiness";
 import type { BrowserEngine } from "@multizen/settings-store";
 import { CdpSession } from "@multizen/cdp-driver";
 import type { ChromiumBootstrap } from "./ChromiumBootstrap";
@@ -417,9 +418,12 @@ export class ChromiumBrowserDriver extends EventEmitter implements BrowserDriver
     const startedAt = new Date().toISOString();
     const cdpEndpoint = `http://127.0.0.1:${port}`;
 
-    const session = new CdpSession({ port });
-    await waitForCdpReady(port, 10000);
-    await session.connect();
+    const session = new CdpSession({ port, engine });
+    // Staged readiness: /json/version → a page target exists → connect+attach,
+    // all within one budget. Guarantees the profile is actually drivable before
+    // launch() resolves, so an MCP navigate/extract right after launch can't
+    // race a not-yet-ready CDP endpoint.
+    await waitForCdpSessionReady(port, session, 15000);
 
     // Apply per-target emulation: timezone, locale, Sec-CH-UA via
     // userAgentMetadata (works on stock Chromium — no patches needed!),
@@ -721,6 +725,17 @@ export class ChromiumBrowserDriver extends EventEmitter implements BrowserDriver
   async screenshot(profileId: ProfileId): Promise<{ pngBase64: string }> {
     const session = this.requireSession(profileId);
     return session.screenshot();
+  }
+
+  async cdpSend(
+    profileId: ProfileId,
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+    opts?: { safe?: boolean },
+  ): Promise<unknown> {
+    const session = this.requireSession(profileId);
+    return session.cdpSend(method, params, sessionId, opts);
   }
 
   async closeAll(): Promise<void> {
@@ -1837,23 +1852,6 @@ async function ensureSessionRestore(dataDir: string): Promise<void> {
   const tmpPath = `${prefsPath}.multizen.tmp`;
   await fsp.writeFile(tmpPath, JSON.stringify(prefs));
   await fsp.rename(tmpPath, prefsPath);
-}
-
-async function waitForCdpReady(port: number, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown = null;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`http://127.0.0.1:${port}/json/version`);
-      if (res.ok) return;
-    } catch (e) {
-      lastError = e;
-    }
-    await sleep(150);
-  }
-  throw new Error(
-    `CDP did not become ready on port ${port} within ${timeoutMs}ms: ${String(lastError)}`,
-  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/apps/desktop/src/main/cdpReadiness.test.ts
+++ b/apps/desktop/src/main/cdpReadiness.test.ts
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  waitForCdpSessionReady,
+  type ReadinessDeps,
+  type ReadinessResponseLike,
+} from "./cdpReadiness.ts";
+
+/**
+ * Coverage for the staged CDP readiness ladder. `fetch` and `sleep` are
+ * injected so each stage's success and budget-exhaustion paths can be checked
+ * deterministically without a real Chromium DevTools endpoint. A small real
+ * (capped) sleep lets the wall-clock budget actually elapse.
+ */
+
+function ok(json: unknown): ReadinessResponseLike {
+  return { ok: true, json: async () => json };
+}
+function notOk(): ReadinessResponseLike {
+  return { ok: false, json: async () => ({}) };
+}
+
+function makeDeps(opts: {
+  version?: () => ReadinessResponseLike;
+  list?: () => ReadinessResponseLike;
+}): { deps: ReadinessDeps; fetches: string[] } {
+  const fetches: string[] = [];
+  const deps: ReadinessDeps = {
+    fetch: async (url: string) => {
+      fetches.push(url);
+      if (url.includes("/json/version")) return opts.version ? opts.version() : notOk();
+      if (url.includes("/json/list")) return opts.list ? opts.list() : notOk();
+      return notOk();
+    },
+    // Capped real delay so Date.now()-based budgets elapse without a busy spin.
+    sleep: (ms: number) => new Promise((r) => setTimeout(r, Math.min(ms, 5))),
+  };
+  return { deps, fetches };
+}
+
+test("resolves once /json/version, a page target, and connect() all succeed", async () => {
+  const { deps, fetches } = makeDeps({
+    version: () => ok({}),
+    list: () => ok([{ type: "page" }]),
+  });
+  let connects = 0;
+  const session = {
+    connect: async () => {
+      connects += 1;
+    },
+  };
+  await assert.doesNotReject(waitForCdpSessionReady(9300, session, 1000, deps));
+  assert.equal(connects, 1);
+  assert.ok(fetches.some((u) => u.includes("/json/version")));
+  assert.ok(fetches.some((u) => u.includes("/json/list")));
+});
+
+test("throws a stage-1 error when /json/version never answers within the budget", async () => {
+  const { deps } = makeDeps({
+    version: () => {
+      throw new Error("ECONNREFUSED");
+    },
+  });
+  const session = { connect: async () => {} };
+  await assert.rejects(waitForCdpSessionReady(9301, session, 60, deps), (e: unknown) => {
+    const msg = (e as Error).message;
+    assert.match(msg, /\/json\/version not ready/);
+    assert.match(msg, /60ms/);
+    return true;
+  });
+});
+
+test("throws a stage-2 error when no page target appears within the budget", async () => {
+  const { deps } = makeDeps({
+    version: () => ok({}),
+    list: () => ok([{ type: "browser" }]), // a target, but never a page
+  });
+  const session = { connect: async () => {} };
+  await assert.rejects(
+    waitForCdpSessionReady(9302, session, 60, deps),
+    /No CDP page target/,
+  );
+});
+
+test("throws a stage-3 error when connect()/attach keeps failing within the budget", async () => {
+  const { deps } = makeDeps({
+    version: () => ok({}),
+    list: () => ok([{ type: "page" }]),
+  });
+  const session = {
+    connect: async () => {
+      throw new Error("attach refused");
+    },
+  };
+  await assert.rejects(
+    waitForCdpSessionReady(9303, session, 60, deps),
+    /connect\/attach failed/,
+  );
+});
+
+test("retries connect() and succeeds on a later attempt (idempotent connect)", async () => {
+  const { deps } = makeDeps({
+    version: () => ok({}),
+    list: () => ok([{ type: "page" }]),
+  });
+  let attempts = 0;
+  const session = {
+    connect: async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error("not attached yet");
+    },
+  };
+  await assert.doesNotReject(waitForCdpSessionReady(9304, session, 2000, deps));
+  assert.equal(attempts, 3);
+});

--- a/apps/desktop/src/main/cdpReadiness.ts
+++ b/apps/desktop/src/main/cdpReadiness.ts
@@ -1,0 +1,96 @@
+/**
+ * Staged CDP readiness within a single fixed budget, reusing the supplied
+ * session (connect() is idempotent). Stages, each polled on a fixed backoff:
+ *   1. `/json/version` answers — the DevTools HTTP endpoint is up.
+ *   2. `/json/list` reports at least one `type === "page"` target — Chromium
+ *      has actually opened a page (chrome-remote-interface attaches to a page
+ *      by default, so connecting before one exists throws).
+ *   3. `session.connect()` succeeds — websocket attached + Page.enable done.
+ *
+ * Throws if the budget is exhausted at any stage; the caller is responsible
+ * for tearing down the half-launched browser.
+ *
+ * `fetch` and `sleep` are injectable so the staged ladder / budget behaviour
+ * can be exercised without a real Chromium endpoint.
+ */
+export interface ReadinessResponseLike {
+  ok: boolean;
+  json: () => Promise<unknown>;
+}
+
+export interface ReadinessSession {
+  connect(): Promise<void>;
+}
+
+export interface ReadinessDeps {
+  fetch: (url: string) => Promise<ReadinessResponseLike>;
+  sleep: (ms: number) => Promise<void>;
+}
+
+const defaultReadinessDeps: ReadinessDeps = {
+  fetch: (url) => fetch(url),
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+};
+
+export async function waitForCdpSessionReady(
+  port: number,
+  session: ReadinessSession,
+  budgetMs: number,
+  deps: ReadinessDeps = defaultReadinessDeps,
+): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  let lastError: unknown = null;
+
+  // Stage 1: /json/version answers.
+  while (Date.now() < deadline) {
+    try {
+      const res = await deps.fetch(`http://127.0.0.1:${port}/json/version`);
+      if (res.ok) {
+        lastError = null;
+        break;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+    await deps.sleep(200);
+  }
+  if (Date.now() >= deadline) {
+    throw new Error(
+      `CDP /json/version not ready on port ${port} within ${budgetMs}ms: ${String(lastError)}`,
+    );
+  }
+
+  // Stage 2: a page target exists.
+  while (Date.now() < deadline) {
+    try {
+      const res = await deps.fetch(`http://127.0.0.1:${port}/json/list`);
+      if (res.ok) {
+        const targets = (await res.json()) as Array<{ type?: string }>;
+        if (targets.some((t) => t.type === "page")) {
+          lastError = null;
+          break;
+        }
+      }
+    } catch (e) {
+      lastError = e;
+    }
+    await deps.sleep(200);
+  }
+  if (Date.now() >= deadline) {
+    throw new Error(`No CDP page target on port ${port} within ${budgetMs}ms: ${String(lastError)}`);
+  }
+
+  // Stage 3: connect + attach (idempotent; returns immediately once attached).
+  while (Date.now() < deadline) {
+    try {
+      await session.connect();
+      return;
+    } catch (e) {
+      lastError = e;
+      await deps.sleep(200);
+    }
+  }
+  throw new Error(
+    `CDP connect/attach failed on port ${port} within ${budgetMs}ms: ${String(lastError)}`,
+  );
+}

--- a/packages/cdp-driver/package.json
+++ b/packages/cdp-driver/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import ../mcp-server/node_modules/tsx/dist/loader.mjs --test src/CdpSession.test.ts"
   },
   "dependencies": {
     "@multizen/types": "workspace:*",

--- a/packages/cdp-driver/src/CdpSession.test.ts
+++ b/packages/cdp-driver/src/CdpSession.test.ts
@@ -1,0 +1,211 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { CdpSession } from "./CdpSession.js";
+
+/**
+ * Unit/integration coverage for the stealth-preserving `cdpSend` primitive.
+ *
+ * We bypass the real chrome-remote-interface transport by injecting a fake
+ * client straight onto the session (the only thing `connect()` would set), then
+ * record the exact sequence of CDP commands the safe layer emits. This lets us
+ * assert the stealth invariants precisely without a browser.
+ */
+
+interface SendCall {
+  method: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+}
+
+interface FakeClient {
+  client: { send: (m: string, p?: Record<string, unknown>, s?: string) => Promise<unknown> };
+  calls: SendCall[];
+  methods: () => string[];
+}
+
+function makeFakeClient(opts: { throwOn?: (method: string, callIndex: number) => boolean } = {}): FakeClient {
+  const calls: SendCall[] = [];
+  let i = 0;
+  const client = {
+    send: async (method: string, params?: Record<string, unknown>, sessionId?: string): Promise<unknown> => {
+      const idx = i++;
+      calls.push({ method, params, sessionId });
+      if (opts.throwOn?.(method, idx)) throw new Error(`fake CDP failure: ${method}`);
+      return { ok: true, method };
+    },
+  };
+  return { client, calls, methods: () => calls.map((c) => c.method) };
+}
+
+/** Build a session and graft the fake client on, skipping the real connect(). */
+function sessionWith(fake: FakeClient, engine?: string): CdpSession {
+  const s = new CdpSession({ port: 0, engine });
+  (s as unknown as { client: unknown }).client = fake.client;
+  return s;
+}
+
+function refcount(s: CdpSession): Map<string, number> {
+  return (s as unknown as { safeEnableRefcount: Map<string, number> }).safeEnableRefcount;
+}
+
+// ── connect-domain protection (Page is sacred) ───────────────────────────────
+
+test("safe cdp_send never disables a connect-enabled domain (Page.enable is a no-op for disable)", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake);
+  await s.cdpSend("Page.enable");
+  assert.deepEqual(fake.methods(), ["Page.enable"]);
+  assert.ok(!fake.methods().includes("Page.disable"), "Page must never be disabled");
+  assert.equal(refcount(s).size, 0);
+});
+
+// ── allowlisted domain: enable is paired with a disable ──────────────────────
+
+test("safe cdp_send pairs an allowlisted *.enable with a *.disable (Accessibility)", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake);
+  await s.cdpSend("Accessibility.enable");
+  assert.deepEqual(fake.methods(), ["Accessibility.enable", "Accessibility.disable"]);
+  assert.equal(refcount(s).size, 0, "refcount must return to empty after the paired disable");
+});
+
+test("safe cdp_send pairs Runtime.enable with Runtime.disable on a non-anti-detect engine", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake, "cft");
+  await s.cdpSend("Runtime.enable");
+  assert.deepEqual(fake.methods(), ["Runtime.enable", "Runtime.disable"]);
+});
+
+test("the paired disable is threaded through the same sessionId as the enable", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake);
+  await s.cdpSend("Accessibility.enable", undefined, "SESS-1");
+  assert.deepEqual(
+    fake.calls.map((c) => [c.method, c.sessionId]),
+    [
+      ["Accessibility.enable", "SESS-1"],
+      ["Accessibility.disable", "SESS-1"],
+    ],
+  );
+});
+
+// ── unknown domains are left strictly alone (allowlist, not a heuristic) ──────
+
+test("safe cdp_send does NOT pair a disable for a domain outside the allowlist", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake);
+  await s.cdpSend("Foo.enable");
+  assert.deepEqual(fake.methods(), ["Foo.enable"], "unknown domains must not be auto-disabled");
+  assert.equal(refcount(s).size, 0);
+});
+
+// ── CloakBrowser: refuse risky enables at enable time ────────────────────────
+
+for (const method of ["Runtime.enable", "Network.enable"]) {
+  test(`safe cdp_send on cloakbrowser refuses ${method} with a clear error and never sends it`, async () => {
+    const fake = makeFakeClient();
+    const s = sessionWith(fake, "cloakbrowser");
+    await assert.rejects(s.cdpSend(method), (e: unknown) => {
+      const msg = (e as Error).message;
+      assert.match(msg, /refus/i);
+      assert.match(msg, /cdp_send_no_safety/);
+      return true;
+    });
+    assert.deepEqual(fake.methods(), [], "the risky enable must not reach the transport");
+    assert.equal(refcount(s).size, 0);
+  });
+}
+
+test("safe cdp_send on cloakbrowser STILL pairs a non-risky enable (DOM) normally", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake, "cloakbrowser");
+  await s.cdpSend("DOM.enable");
+  assert.deepEqual(fake.methods(), ["DOM.enable", "DOM.disable"]);
+});
+
+test("safe cdp_send on cloakbrowser does not touch Page (connect domain) at all", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake, "cloakbrowser");
+  await s.cdpSend("Page.enable");
+  assert.deepEqual(fake.methods(), ["Page.enable"]);
+});
+
+// ── no-safety passthrough ────────────────────────────────────────────────────
+
+test("cdp_send_no_safety is a pure passthrough: no disable, even for risky enables", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake, "cloakbrowser");
+  await s.cdpSend("Network.enable", undefined, undefined, { safe: false });
+  assert.deepEqual(fake.methods(), ["Network.enable"], "no auto-disable in unsafe mode");
+  assert.equal(refcount(s).size, 0);
+});
+
+test("cdp_send_no_safety on cloakbrowser does not apply the risky-enable refusal", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake, "cloakbrowser");
+  // Must resolve (not throw) — the caller owns the consequences.
+  await s.cdpSend("Runtime.enable", undefined, undefined, { safe: false });
+  assert.deepEqual(fake.methods(), ["Runtime.enable"]);
+});
+
+// ── wrappers' underlying calls never enable a domain ─────────────────────────
+
+test("typical wrapper calls (Runtime.evaluate, Network.getCookies, Target.*) never enable/disable", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake);
+  await s.cdpSend("Runtime.evaluate", { expression: "1", returnByValue: true });
+  await s.cdpSend("Network.getCookies", {});
+  await s.cdpSend("Network.setCookies", { cookies: [] });
+  await s.cdpSend("Target.getTargets", {});
+  await s.cdpSend("Target.createTarget", { url: "about:blank" });
+  assert.deepEqual(fake.methods(), [
+    "Runtime.evaluate",
+    "Network.getCookies",
+    "Network.setCookies",
+    "Target.getTargets",
+    "Target.createTarget",
+  ]);
+  assert.ok(!fake.methods().some((m) => /\.(enable|disable)$/.test(m)));
+});
+
+// ── concurrency: refcount keeps the disable until the last enable finishes ────
+
+test("parallel safe enables of one domain refcount to a single trailing disable", async () => {
+  const fake = makeFakeClient();
+  const s = sessionWith(fake);
+  await Promise.all([s.cdpSend("Runtime.enable"), s.cdpSend("Runtime.enable")]);
+
+  const enables = fake.methods().filter((m) => m === "Runtime.enable").length;
+  const disables = fake.methods().filter((m) => m === "Runtime.disable").length;
+  assert.equal(enables, 2, "both enables must reach the transport");
+  assert.equal(disables, 1, "only one disable once the refcount hits zero");
+  assert.equal(fake.methods().at(-1), "Runtime.disable", "disable must come after both enables");
+  assert.equal(refcount(s).size, 0);
+});
+
+// ── exception safety: a throwing enable must not pin the domain ───────────────
+
+test("an exception after increment still decrements the refcount (domain not pinned)", async () => {
+  // Throw only on the FIRST Runtime.enable so we can prove the domain is not
+  // left pinned: a later enable must behave normally.
+  const fake = makeFakeClient({ throwOn: (method, idx) => method === "Runtime.enable" && idx === 0 });
+  const s = sessionWith(fake, "cft");
+
+  await assert.rejects(s.cdpSend("Runtime.enable"), /fake CDP failure/);
+  assert.equal(refcount(s).size, 0, "refcount must be cleared even when the enable throws");
+
+  // A subsequent enable enables + pairs a disable as usual — proof the domain
+  // was never stuck in the 'enabled' accounting state.
+  await s.cdpSend("Runtime.enable");
+  assert.equal(refcount(s).size, 0);
+  const tail = fake.methods().slice(-2);
+  assert.deepEqual(tail, ["Runtime.enable", "Runtime.disable"]);
+});
+
+// ── require(): cdpSend before connect throws a clear error ────────────────────
+
+test("cdp_send before connect() throws a clear 'not connected' error", async () => {
+  const s = new CdpSession({ port: 0 });
+  await assert.rejects(s.cdpSend("Runtime.evaluate"), /not connected/i);
+});

--- a/packages/cdp-driver/src/CdpSession.ts
+++ b/packages/cdp-driver/src/CdpSession.ts
@@ -45,7 +45,35 @@ export interface CdpSessionOptions {
   port: number;
   /** Optional host override, defaults to localhost */
   host?: string;
+  /**
+   * Browser engine identifier (e.g. "cft" | "cloakbrowser"). Lets the safe
+   * `cdpSend` layer refuse `*.enable` of DCHECK-sensitive domains on
+   * anti-detect forks where enabling — not the paired disable — is what
+   * trips the automation tripwire.
+   */
+  engine?: string;
 }
+
+/**
+ * Domains the safe `cdpSend` layer is allowed to enable-then-disable. We use
+ * an explicit allowlist (domain → has a paired `*.disable`) instead of a
+ * string heuristic on `*.enable` so unknown domains are never touched.
+ */
+const SAFE_PAIRED_DISABLE_DOMAINS = new Set([
+  "Runtime",
+  "Network",
+  "DOM",
+  "Accessibility",
+  "Log",
+  "Performance",
+]);
+
+/**
+ * Domains whose `*.enable` trips the DCHECK on anti-detect Chromium forks
+ * (CloakBrowser) at enable time. A paired disable cannot undo it, so safe
+ * mode refuses these enables outright on such engines.
+ */
+const CLOAK_RISKY_ENABLE_DOMAINS = new Set(["Runtime", "Network"]);
 
 /**
  * Thin wrapper around chrome-remote-interface that exposes the
@@ -67,6 +95,19 @@ export class CdpSession {
   private readonly opts: CdpSessionOptions;
   /** Cleanups (e.g. polling intervals) to run on close(). */
   private readonly teardowns: Array<() => void> = [];
+  /**
+   * Domains enabled by {@link connect}. These are part of the stealth-minimal
+   * baseline (currently just `Page`) and must NEVER be disabled by the safe
+   * `cdpSend` layer — `navigate`/`Page.loadEventFired` depend on `Page`.
+   */
+  private readonly connectEnabledDomains = new Set<string>(["Page"]);
+  /**
+   * Per-domain refcount of enables performed by the safe `cdpSend` layer.
+   * Parallel safe calls share the count so they don't clobber each other's
+   * in-flight enable; the paired disable runs only when a domain's count
+   * falls back to 0.
+   */
+  private readonly safeEnableRefcount = new Map<string, number>();
 
   constructor(opts: CdpSessionOptions) {
     this.opts = opts;
@@ -315,6 +356,78 @@ export class CdpSession {
   private require(): CDP.Client {
     if (!this.client) throw new Error("CDP session not connected. Call connect() first.");
     return this.client;
+  }
+
+  /**
+   * Single primitive every CDP tool composes on top of.
+   *
+   * - `safe: false` — pure passthrough. No accounting, no auto-disable. The
+   *   caller owns the stealth consequences (used by `cdp_send_no_safety`).
+   * - `safe: true` (default) — stealth-preserving. If the command is an
+   *   allowlisted `*.enable` for a domain that was NOT enabled at connect, the
+   *   domain is refcounted and a paired `<domain>.disable` is fired once the
+   *   refcount returns to 0. Domains enabled at connect (e.g. `Page`) are
+   *   never disabled. On anti-detect engines, enabling a DCHECK-sensitive
+   *   domain is refused outright (a paired disable cannot undo the enable).
+   *
+   * The convenience wrappers (evaluate_js, cookies, tabs, …) deliberately do
+   * NOT enable any domain — `Runtime.evaluate`, `Network.getCookies`, and the
+   * `Target.*` methods all work without one — so they never touch this path's
+   * accounting branch.
+   */
+  async cdpSend(
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+    opts: { safe?: boolean } = {},
+  ): Promise<unknown> {
+    const client = this.require();
+    const send = buildSender(client, sessionId);
+    const safe = opts.safe ?? true;
+
+    if (!safe) {
+      return send(method, params);
+    }
+
+    const dot = method.indexOf(".");
+    const domain = dot > 0 ? method.slice(0, dot) : "";
+    const isEnable = dot > 0 && method.slice(dot + 1) === "enable";
+    // A "tracked" enable is one the safe layer is responsible for undoing:
+    // an allowlisted domain that wasn't already enabled at connect.
+    const tracked =
+      isEnable && SAFE_PAIRED_DISABLE_DOMAINS.has(domain) && !this.connectEnabledDomains.has(domain);
+
+    if (tracked && this.opts.engine === "cloakbrowser" && CLOAK_RISKY_ENABLE_DOMAINS.has(domain)) {
+      throw new Error(
+        `Refusing ${method} in safe mode: enabling ${domain} trips the anti-detect ` +
+          `DCHECK on this engine at enable time, and a paired disable cannot undo it. ` +
+          `Use cdp_send_no_safety if you accept the stealth/crash risk.`,
+      );
+    }
+
+    if (tracked) {
+      // Increment BEFORE the call so a concurrent safe cdpSend sees the
+      // in-flight enable and won't issue its own redundant disable.
+      this.safeEnableRefcount.set(domain, (this.safeEnableRefcount.get(domain) ?? 0) + 1);
+    }
+
+    try {
+      return await send(method, params);
+    } finally {
+      // Decrement in finally so an exception thrown after a successful enable
+      // doesn't strand the domain enabled.
+      if (tracked) {
+        const next = (this.safeEnableRefcount.get(domain) ?? 1) - 1;
+        if (next <= 0) {
+          this.safeEnableRefcount.delete(domain);
+          await buildSender(client, sessionId)(`${domain}.disable`).catch(() => {
+            // Domain may already be disabled / session gone — best effort.
+          });
+        } else {
+          this.safeEnableRefcount.set(domain, next);
+        }
+      }
+    }
   }
 
   async navigate(url: string, opts: { timeoutMs?: number } = {}): Promise<{ url: string; title: string }> {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/standalone.ts",
+    "test": "node --import tsx --test src/cdpTools.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/mcp-server/src/ActivityLog.ts
+++ b/packages/mcp-server/src/ActivityLog.ts
@@ -73,15 +73,24 @@ export class ActivityLog extends EventEmitter {
 }
 
 function sanitize(args: Record<string, unknown>): Record<string, unknown> {
-  // For now we don't have any obviously secret fields in tool args.
-  // When `type` is added with passwords, redact here.
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(args)) {
     if (k === "text" && typeof v === "string" && v.length > 80) {
       out[k] = `${v.slice(0, 60)}…[${v.length} chars]`;
+    } else if (k === "proxy" && v && typeof v === "object") {
+      // Proxy credentials are secrets — never let them reach the activity
+      // stream / audit log.
+      out[k] = redactProxy(v as Record<string, unknown>);
     } else {
       out[k] = v;
     }
   }
+  return out;
+}
+
+function redactProxy(proxy: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...proxy };
+  if (typeof out.username === "string" && out.username.length > 0) out.username = "***";
+  if (typeof out.password === "string" && out.password.length > 0) out.password = "***";
   return out;
 }

--- a/packages/mcp-server/src/MockBrowserDriver.ts
+++ b/packages/mcp-server/src/MockBrowserDriver.ts
@@ -74,4 +74,24 @@ export class MockBrowserDriver implements BrowserDriver {
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
     };
   }
+
+  async cdpSend(
+    profileId: ProfileId,
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+    opts?: { safe?: boolean },
+  ): Promise<unknown> {
+    const r = this.running.get(profileId);
+    if (!r) throw new Error("not running");
+    // Echo the request back so MCP clients can exercise the CDP tool surfaces
+    // end-to-end against the mock without a real browser.
+    return {
+      mock: true,
+      method,
+      params: params ?? {},
+      sessionId: sessionId ?? null,
+      safe: opts?.safe ?? true,
+    };
+  }
 }

--- a/packages/mcp-server/src/cdpTools.test.ts
+++ b/packages/mcp-server/src/cdpTools.test.ts
@@ -1,0 +1,505 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createMultizenMcpServer, type BrowserDriver } from "./server.js";
+import { MockBrowserDriver } from "./MockBrowserDriver.js";
+import type { ProfileManager } from "@multizen/profile-manager";
+import type { LaunchedProfile, ProfileId } from "@multizen/types";
+
+/**
+ * End-to-end exercise of the MCP server CDP tool surfaces. We connect a real
+ * MCP `Client` to a real `Server` over an in-memory transport pair, so every
+ * assertion goes through genuine `tools/list` + `tools/call` JSON-RPC round
+ * trips (including Zod validation and the dispatch switch). The browser layer
+ * is faked so we can capture exactly what `dispatch()` asks the driver to do.
+ */
+
+const NEW_TOOLS = [
+  "cdp_send",
+  "cdp_send_no_safety",
+  "evaluate_js",
+  "wait_for_selector",
+  "get_cookies",
+  "set_cookies",
+  "list_tabs",
+  "new_tab",
+  "activate_tab",
+  "close_tab",
+  "wait_for_navigation",
+  "wait_for_load",
+] as const;
+
+interface CdpCall {
+  profileId: string;
+  method: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+  opts?: { safe?: boolean };
+}
+
+/** A BrowserDriver that records every cdpSend and returns a configurable
+ *  response, so dispatch composition (method + params + safe flag) is
+ *  observable without a browser. */
+class SpyDriver implements BrowserDriver {
+  readonly running = new Set<string>();
+  readonly calls: CdpCall[] = [];
+  respond: (method: string, params?: Record<string, unknown>) => unknown = () => ({ ok: true });
+
+  async launch(profileId: ProfileId): Promise<LaunchedProfile> {
+    this.running.add(profileId);
+    return {
+      id: profileId,
+      cdpEndpoint: "http://127.0.0.1:0",
+      pid: 1,
+      startedAt: new Date().toISOString(),
+    };
+  }
+  async close(profileId: ProfileId): Promise<void> {
+    this.running.delete(profileId);
+  }
+  isRunning(profileId: ProfileId): boolean {
+    return this.running.has(profileId);
+  }
+  async navigate(_profileId: ProfileId, url: string): Promise<{ url: string }> {
+    return { url };
+  }
+  async click(): Promise<{ ok: true }> {
+    return { ok: true };
+  }
+  async type(): Promise<{ ok: true }> {
+    return { ok: true };
+  }
+  async extract(): Promise<{ result: unknown }> {
+    return { result: {} };
+  }
+  async screenshot(): Promise<{ pngBase64: string }> {
+    return { pngBase64: "" };
+  }
+  async cdpSend(
+    profileId: ProfileId,
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+    opts?: { safe?: boolean },
+  ): Promise<unknown> {
+    this.calls.push({ profileId, method, params, sessionId, opts });
+    return this.respond(method, params);
+  }
+}
+
+async function connect(driver: BrowserDriver): Promise<Client> {
+  // The profile manager is never touched by the CDP tool paths (they only
+  // need isRunning + cdpSend), so a bare stub is sufficient here.
+  const profileManager = {} as unknown as ProfileManager;
+  const { server } = createMultizenMcpServer({ profileManager, browserDriver: driver });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return client;
+}
+
+interface CallResult {
+  isError: boolean;
+  parsed: any;
+}
+
+async function call(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<CallResult> {
+  const res = await client.callTool({ name, arguments: args });
+  const content = res.content as Array<{ type: string; text: string }>;
+  const text = content[0]?.text ?? "";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = text;
+  }
+  return { isError: res.isError === true, parsed };
+}
+
+/** No convenience wrapper is allowed to enable a CDP domain — that is the
+ *  whole stealth point of composing them over the bare primitive. */
+function assertNoDomainEnable(spy: SpyDriver): void {
+  for (const c of spy.calls) {
+    assert.ok(
+      !/\.enable$/.test(c.method),
+      `wrapper unexpectedly issued a domain enable: ${c.method}`,
+    );
+  }
+}
+
+// ── tools/list registration ─────────────────────────────────────────────────
+
+test("tools/list exposes all 12 CDP tool surfaces with object input schemas", async () => {
+  const client = await connect(new SpyDriver());
+  const { tools } = await client.listTools();
+  const byName = new Map(tools.map((t) => [t.name, t]));
+  for (const name of NEW_TOOLS) {
+    const tool = byName.get(name);
+    assert.ok(tool, `tool ${name} is not registered in TOOL_DEFINITIONS`);
+    assert.equal(typeof tool!.description, "string");
+    assert.ok((tool!.description ?? "").length > 0, `tool ${name} has no description`);
+    assert.equal((tool!.inputSchema as { type?: string }).type, "object");
+  }
+  await client.close();
+});
+
+test("cdp_send_no_safety description explicitly warns it bypasses stealth", async () => {
+  const client = await connect(new SpyDriver());
+  const { tools } = await client.listTools();
+  const tool = tools.find((t) => t.name === "cdp_send_no_safety");
+  assert.ok(tool);
+  const desc = tool!.description ?? "";
+  assert.match(desc, /bypass/i);
+  assert.match(desc, /stealth/i);
+  await client.close();
+});
+
+// ── safe / no-safety routing ────────────────────────────────────────────────
+
+test("cdp_send routes to driver.cdpSend with safe:true and verbatim method/params", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  await call(client, "cdp_send", {
+    profile_id: "p1",
+    method: "Page.captureScreenshot",
+    params: { format: "png" },
+    sessionId: "S1",
+  });
+  const c = spy.calls.at(-1)!;
+  assert.equal(c.method, "Page.captureScreenshot");
+  assert.deepEqual(c.params, { format: "png" });
+  assert.equal(c.sessionId, "S1");
+  assert.equal(c.opts?.safe, true);
+  await client.close();
+});
+
+test("cdp_send_no_safety routes to driver.cdpSend with safe:false", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  await call(client, "cdp_send_no_safety", { profile_id: "p1", method: "Network.enable" });
+  const c = spy.calls.at(-1)!;
+  assert.equal(c.method, "Network.enable");
+  assert.equal(c.opts?.safe, false);
+  await client.close();
+});
+
+// ── convenience wrappers compose the right CDP method without enabling ───────
+
+test("evaluate_js composes Runtime.evaluate{returnByValue} (no domain enable)", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  await call(client, "evaluate_js", {
+    profile_id: "p1",
+    expression: "1 + 1",
+    sessionId: "S2",
+  });
+  const c = spy.calls.at(-1)!;
+  assert.equal(c.method, "Runtime.evaluate");
+  assert.deepEqual(c.params, { expression: "1 + 1", returnByValue: true });
+  assert.equal(c.sessionId, "S2");
+  assert.equal(c.opts?.safe, true);
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+test("wait_for_selector polls Runtime.evaluate(querySelector) and reports found", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  spy.respond = (method) =>
+    method === "Runtime.evaluate" ? { result: { value: true } } : { ok: true };
+  const client = await connect(spy);
+  const { parsed } = await call(client, "wait_for_selector", {
+    profile_id: "p1",
+    selector: "#login",
+  });
+  assert.deepEqual(parsed, { found: true, selector: "#login" });
+  const c = spy.calls.at(-1)!;
+  assert.equal(c.method, "Runtime.evaluate");
+  assert.equal(c.params?.expression, '!!document.querySelector("#login")');
+  assert.equal(c.params?.returnByValue, true);
+  assert.equal(c.opts?.safe, true);
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+test("wait_for_selector returns found:false when the budget elapses", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  spy.respond = () => ({ result: { value: false } });
+  const client = await connect(spy);
+  const { parsed } = await call(client, "wait_for_selector", {
+    profile_id: "p1",
+    selector: "#never",
+    timeout_ms: 1,
+  });
+  assert.deepEqual(parsed, { found: false, selector: "#never" });
+  await client.close();
+});
+
+// ── pollUntil scoped-retry on transient navigation errors ────────────────────
+// pollUntil (shared by wait_for_selector / wait_for_navigation / wait_for_load)
+// must keep polling through transient "execution context destroyed" failures
+// raised mid-navigation, but never mask a real error.
+
+test("wait_for_selector swallows transient navigation errors and resolves once the context returns", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  let attempts = 0;
+  spy.respond = (method) => {
+    if (method !== "Runtime.evaluate") return { ok: true };
+    attempts += 1;
+    // The first couple of evaluations land while the page is reloading.
+    if (attempts <= 2) throw new Error("Execution context was destroyed.");
+    return { result: { value: true } };
+  };
+  const client = await connect(spy);
+  const { isError, parsed } = await call(client, "wait_for_selector", {
+    profile_id: "p1",
+    selector: "#login",
+  });
+  assert.equal(isError, false);
+  assert.deepEqual(parsed, { found: true, selector: "#login" });
+  assert.ok(attempts >= 3, "retried through the transient errors before succeeding");
+  await client.close();
+});
+
+test("wait_for_selector rethrows a non-transient error immediately (no retry to timeout)", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  spy.respond = (method) => {
+    if (method === "Runtime.evaluate") throw new Error("SyntaxError: 'foo[' is not a valid selector");
+    return { ok: true };
+  };
+  const client = await connect(spy);
+  // A generous budget: if a real error were (wrongly) retried this would spin
+  // ~30s and rack up many calls. We assert it returns at once after one check.
+  const { isError, parsed } = await call(client, "wait_for_selector", {
+    profile_id: "p1",
+    selector: "foo[",
+    timeout_ms: 30000,
+  });
+  assert.equal(isError, true);
+  assert.match(parsed.error.message, /not a valid selector/i);
+  assert.doesNotMatch(parsed.error.message, /timed out/i, "surfaced the real error, not a timeout");
+  const evals = spy.calls.filter((c) => c.method === "Runtime.evaluate");
+  assert.equal(evals.length, 1, "thrown on the first check — no retry loop");
+  await client.close();
+});
+
+test("wait_for_selector throws a clear timeout when transient errors persist past the budget", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  spy.respond = (method) => {
+    if (method === "Runtime.evaluate") throw new Error("Cannot find context with specified id");
+    return { ok: true };
+  };
+  const client = await connect(spy);
+  const { isError, parsed } = await call(client, "wait_for_selector", {
+    profile_id: "p1",
+    selector: "#login",
+    timeout_ms: 1,
+  });
+  assert.equal(isError, true);
+  assert.match(parsed.error.message, /timed out/i);
+  assert.match(parsed.error.message, /Cannot find context/i, "names the underlying transient error");
+  await client.close();
+});
+
+test("get_cookies composes Network.getCookies with an optional url filter", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+
+  await call(client, "get_cookies", { profile_id: "p1" });
+  assert.equal(spy.calls.at(-1)!.method, "Network.getCookies");
+  assert.deepEqual(spy.calls.at(-1)!.params, {});
+
+  await call(client, "get_cookies", { profile_id: "p1", urls: ["https://example.com"] });
+  assert.deepEqual(spy.calls.at(-1)!.params, { urls: ["https://example.com"] });
+  assert.equal(spy.calls.at(-1)!.opts?.safe, true);
+
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+// NOTE: the implementation uses Network.setCookies (PLURAL) — a known,
+// intentional deviation from the plan's "Network.setCookie". The test asserts
+// the actual shipped behaviour.
+test("set_cookies composes Network.setCookies (plural) with the cookie batch", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  const cookies = [
+    { name: "sid", value: "abc", domain: "example.com" },
+    { name: "theme", value: "dark" },
+  ];
+  await call(client, "set_cookies", { profile_id: "p1", cookies });
+  const c = spy.calls.at(-1)!;
+  assert.equal(c.method, "Network.setCookies");
+  assert.deepEqual(c.params, { cookies });
+  assert.equal(c.opts?.safe, true);
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+test("list_tabs composes Target.getTargets", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  await call(client, "list_tabs", { profile_id: "p1" });
+  const c = spy.calls.at(-1)!;
+  assert.equal(c.method, "Target.getTargets");
+  assert.deepEqual(c.params, {});
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+test("new_tab composes Target.createTarget (defaulting url to about:blank)", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+
+  await call(client, "new_tab", { profile_id: "p1" });
+  assert.equal(spy.calls.at(-1)!.method, "Target.createTarget");
+  assert.deepEqual(spy.calls.at(-1)!.params, { url: "about:blank" });
+
+  await call(client, "new_tab", { profile_id: "p1", url: "https://example.com" });
+  assert.deepEqual(spy.calls.at(-1)!.params, { url: "https://example.com" });
+
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+test("activate_tab and close_tab compose Target.activateTarget / Target.closeTarget", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+
+  await call(client, "activate_tab", { profile_id: "p1", target_id: "T7" });
+  assert.equal(spy.calls.at(-1)!.method, "Target.activateTarget");
+  assert.deepEqual(spy.calls.at(-1)!.params, { targetId: "T7" });
+
+  await call(client, "close_tab", { profile_id: "p1", target_id: "T7" });
+  assert.equal(spy.calls.at(-1)!.method, "Target.closeTarget");
+  assert.deepEqual(spy.calls.at(-1)!.params, { targetId: "T7" });
+
+  assertNoDomainEnable(spy);
+  await client.close();
+});
+
+// NOTE: wait_for_navigation / wait_for_load poll document.readyState === "complete"
+// via Runtime.evaluate — a known, intentional deviation from the plan's
+// Page.loadEventFired event subscription.
+for (const name of ["wait_for_navigation", "wait_for_load"] as const) {
+  test(`${name} polls document.readyState and reports loaded`, async () => {
+    const spy = new SpyDriver();
+    spy.running.add("p1");
+    spy.respond = (method) =>
+      method === "Runtime.evaluate" ? { result: { value: "complete" } } : { ok: true };
+    const client = await connect(spy);
+    const { parsed } = await call(client, name, { profile_id: "p1" });
+    assert.deepEqual(parsed, { loaded: true });
+    const c = spy.calls.at(-1)!;
+    assert.equal(c.method, "Runtime.evaluate");
+    assert.equal(c.params?.expression, "document.readyState");
+    assert.equal(c.params?.returnByValue, true);
+    assert.equal(c.opts?.safe, true);
+    assertNoDomainEnable(spy);
+    await client.close();
+  });
+}
+
+// ── negative / validation paths ─────────────────────────────────────────────
+
+test("CDP tools require a running profile and return a clear error otherwise", async () => {
+  const spy = new SpyDriver(); // nothing running
+  const client = await connect(spy);
+  const { isError, parsed } = await call(client, "cdp_send", {
+    profile_id: "ghost",
+    method: "Runtime.evaluate",
+  });
+  assert.equal(isError, true);
+  assert.equal(parsed.error.code, "INTERNAL_ERROR");
+  assert.match(parsed.error.message, /not running/i);
+  assert.match(parsed.error.message, /launch_profile/i);
+  assert.equal(spy.calls.length, 0, "driver.cdpSend must not run for a stopped profile");
+  await client.close();
+});
+
+test("cdp_send rejects a missing method via Zod (INVALID_INPUT)", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  const { isError, parsed } = await call(client, "cdp_send", { profile_id: "p1" });
+  assert.equal(isError, true);
+  assert.equal(parsed.error.code, "INVALID_INPUT");
+  assert.equal(spy.calls.length, 0);
+  await client.close();
+});
+
+test("set_cookies rejects an empty cookie array via Zod", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  const { isError, parsed } = await call(client, "set_cookies", { profile_id: "p1", cookies: [] });
+  assert.equal(isError, true);
+  assert.equal(parsed.error.code, "INVALID_INPUT");
+  await client.close();
+});
+
+test("evaluate_js rejects a missing expression via Zod", async () => {
+  const spy = new SpyDriver();
+  spy.running.add("p1");
+  const client = await connect(spy);
+  const { isError, parsed } = await call(client, "evaluate_js", { profile_id: "p1" });
+  assert.equal(isError, true);
+  assert.equal(parsed.error.code, "INVALID_INPUT");
+  await client.close();
+});
+
+// ── the shipped MockBrowserDriver (standalone dev mode) ──────────────────────
+
+test("MockBrowserDriver echoes the safe flag end-to-end through the server", async () => {
+  const mock = new MockBrowserDriver();
+  await mock.launch("p1"); // mark running without needing the profile manager
+  const client = await connect(mock);
+
+  const safe = await call(client, "cdp_send", {
+    profile_id: "p1",
+    method: "Runtime.evaluate",
+    params: { expression: "1" },
+  });
+  assert.equal(safe.parsed.mock, true);
+  assert.equal(safe.parsed.method, "Runtime.evaluate");
+  assert.deepEqual(safe.parsed.params, { expression: "1" });
+  assert.equal(safe.parsed.safe, true);
+
+  const raw = await call(client, "cdp_send_no_safety", {
+    profile_id: "p1",
+    method: "Network.enable",
+  });
+  assert.equal(raw.parsed.safe, false);
+  assert.equal(raw.parsed.method, "Network.enable");
+
+  await client.close();
+});
+
+test("MockBrowserDriver rejects CDP tools for a profile that was never launched", async () => {
+  const mock = new MockBrowserDriver();
+  const client = await connect(mock);
+  const { isError, parsed } = await call(client, "list_tabs", { profile_id: "p1" });
+  assert.equal(isError, true);
+  assert.match(parsed.error.message, /not running/i);
+  await client.close();
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -5,7 +5,19 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { ProfileManager } from "@multizen/profile-manager";
-import type { LaunchedProfile, ProfileId } from "@multizen/types";
+import {
+  reconcileFingerprint,
+  generateFingerprint,
+  deviceCatalog,
+  localeCatalog,
+} from "@multizen/profile-manager";
+import type {
+  LaunchedProfile,
+  ProfileId,
+  FingerprintConfig,
+  UpdateProfileInput,
+  CreateProfileInput,
+} from "@multizen/types";
 import { ActivityLog } from "./ActivityLog.js";
 
 /**
@@ -23,6 +35,18 @@ export interface BrowserDriver {
   type(profileId: ProfileId, selector: string, text: string): Promise<{ ok: true }>;
   extract(profileId: ProfileId): Promise<{ result: unknown }>;
   screenshot(profileId: ProfileId): Promise<{ pngBase64: string }>;
+  /**
+   * Send a raw CDP command. `opts.safe` (default true) auto-disables any
+   * domain the call had to enable so the stealth baseline is preserved; the
+   * convenience CDP tools compose on top of this single primitive.
+   */
+  cdpSend(
+    profileId: ProfileId,
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+    opts?: { safe?: boolean },
+  ): Promise<unknown>;
 }
 
 export interface MultizenMcpServerOptions {
@@ -45,10 +69,107 @@ const TypeSchema = ProfileIdSchema.extend({
   text: z.string(),
 });
 const ExtractSchema = ProfileIdSchema;
+
+// ── CDP tool schemas ────────────────────────────────────────────────────────
+const CdpSendSchema = ProfileIdSchema.extend({
+  method: z.string().min(1),
+  params: z.record(z.unknown()).optional(),
+  sessionId: z.string().optional(),
+});
+const EvaluateJsSchema = ProfileIdSchema.extend({
+  expression: z.string().min(1),
+  sessionId: z.string().optional(),
+});
+const WaitForSelectorSchema = ProfileIdSchema.extend({
+  selector: z.string().min(1),
+  timeout_ms: z.number().int().positive().optional(),
+  sessionId: z.string().optional(),
+});
+const GetCookiesSchema = ProfileIdSchema.extend({
+  urls: z.array(z.string()).optional(),
+  sessionId: z.string().optional(),
+});
+const SetCookiesSchema = ProfileIdSchema.extend({
+  cookies: z
+    .array(z.object({ name: z.string(), value: z.string() }).passthrough())
+    .min(1),
+  sessionId: z.string().optional(),
+});
+const ListTabsSchema = ProfileIdSchema.extend({ sessionId: z.string().optional() });
+const NewTabSchema = ProfileIdSchema.extend({
+  url: z.string().optional(),
+  sessionId: z.string().optional(),
+});
+const TabIdSchema = ProfileIdSchema.extend({
+  target_id: z.string().min(1),
+  sessionId: z.string().optional(),
+});
+const WaitForLoadSchema = ProfileIdSchema.extend({
+  timeout_ms: z.number().int().positive().optional(),
+  sessionId: z.string().optional(),
+});
+
+/** Real device families a fingerprint can impersonate. Mirrors the
+ *  `DeviceFamily` union in @multizen/types; call `list_fingerprint_options`
+ *  for the human-readable catalog. */
+const DEVICE_FAMILIES = [
+  "macbook-pro-14-m3",
+  "macbook-pro-14-m3-pro",
+  "macbook-pro-16-m3-pro",
+  "macbook-air-13-m3",
+  "imac-24-m3",
+  "windows-laptop-intel",
+  "windows-laptop-nvidia",
+  "windows-desktop-nvidia",
+  "linux-desktop-intel",
+] as const;
+
+const ProxySchema = z.object({
+  type: z.enum(["http", "socks5"]),
+  host: z.string().min(1),
+  port: z.number().int().min(1).max(65535),
+  username: z.string().optional(),
+  password: z.string().optional(),
+});
+
+/**
+ * User-facing fingerprint knobs. We deliberately do NOT accept the raw
+ * `FingerprintConfig` (userAgent, clientHints, webgl, …): those surfaces must
+ * stay mutually coherent or detection vendors flag the mismatch. Instead the
+ * caller picks high-level dimensions and `reconcileFingerprint` derives a
+ * coherent config from them.
+ */
+const FingerprintInputSchema = z
+  .object({
+    device: z.enum(DEVICE_FAMILIES).optional(),
+    localeId: z.string().min(1).optional(),
+    timezone: z.string().min(1).optional(),
+    screen: z
+      .object({
+        width: z.number().int().positive(),
+        height: z.number().int().positive(),
+      })
+      .optional(),
+    hardwareConcurrency: z.number().int().positive().optional(),
+    deviceMemory: z.number().positive().optional(),
+  })
+  .strict();
+
 const CreateProfileSchema = z.object({
   name: z.string().min(1),
   notes: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  proxy: ProxySchema.optional(),
+  fingerprint: FingerprintInputSchema.optional(),
+});
+
+const UpdateProfileSchema = ProfileIdSchema.extend({
+  name: z.string().min(1).optional(),
+  notes: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  // `null` clears the proxy; omitted leaves it untouched.
+  proxy: ProxySchema.nullable().optional(),
+  fingerprint: FingerprintInputSchema.optional(),
 });
 
 /**
@@ -77,7 +198,7 @@ export function createMultizenMcpServer(opts: MultizenMcpServerOptions): Multize
   const activityLog = opts.activityLog ?? new ActivityLog();
 
   const server = new Server(
-    { name: "multizen", version: "0.2.0-pre" },
+    { name: "multizen", version: "0.2.11" },
     {
       capabilities: {
         tools: {},
@@ -134,8 +255,70 @@ async function dispatch(
     }
     case "create_profile": {
       const input = CreateProfileSchema.parse(args);
-      const created = profileManager.create(input);
-      return { id: created.id, name: created.name };
+      const createInput: CreateProfileInput = {
+        name: input.name,
+        notes: input.notes,
+        tags: input.tags,
+        proxy: input.proxy,
+      };
+      if (input.fingerprint) {
+        // Seed from a fresh coherent fingerprint, then apply the caller's
+        // high-level knobs so the result stays internally consistent.
+        createInput.fingerprint = reconcileFingerprint(
+          generateFingerprint(),
+          input.fingerprint,
+        );
+      }
+      const created = profileManager.create(createInput);
+      return {
+        id: created.id,
+        name: created.name,
+        proxy: created.proxy,
+        fingerprint: fingerprintSummary(created.fingerprint),
+      };
+    }
+    case "update_profile": {
+      const input = UpdateProfileSchema.parse(args);
+      const existing = profileManager.get(input.profile_id);
+      if (!existing) throw new Error(`Profile ${input.profile_id} not found`);
+
+      const patch: UpdateProfileInput = {};
+      if (input.name !== undefined) patch.name = input.name;
+      if (input.notes !== undefined) patch.notes = input.notes;
+      if (input.tags !== undefined) patch.tags = input.tags;
+      // `proxy: null` clears it, `proxy: {…}` sets it, omitted leaves as-is.
+      if (input.proxy !== undefined) patch.proxy = input.proxy;
+      if (input.fingerprint !== undefined) {
+        patch.fingerprint = reconcileFingerprint(existing.fingerprint, input.fingerprint);
+      }
+
+      const updated = profileManager.update(input.profile_id, patch);
+      return {
+        id: updated.id,
+        name: updated.name,
+        tags: updated.tags,
+        proxy: updated.proxy,
+        fingerprint: fingerprintSummary(updated.fingerprint),
+        // Surface the caveat: a live browser keeps the old proxy/fingerprint.
+        appliesOnNextLaunch: browserDriver.isRunning(input.profile_id),
+      };
+    }
+    case "delete_profile": {
+      const { profile_id } = ProfileIdSchema.parse(args);
+      assertProfileExists(profileManager, profile_id);
+      // Close first so Chromium releases the data dir before we remove it
+      // (on Windows a live handle would otherwise block the rmSync).
+      if (browserDriver.isRunning(profile_id)) {
+        await browserDriver.close(profile_id);
+      }
+      profileManager.delete(profile_id);
+      return { deleted: profile_id };
+    }
+    case "list_fingerprint_options": {
+      return {
+        devices: deviceCatalog(),
+        locales: localeCatalog(),
+      };
     }
     case "launch_profile": {
       const { profile_id } = ProfileIdSchema.parse(args);
@@ -175,10 +358,176 @@ async function dispatch(
       assertProfileRunning(browserDriver, profile_id);
       return await browserDriver.screenshot(profile_id);
     }
+    case "cdp_send": {
+      const { profile_id, method, params, sessionId } = CdpSendSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      return await browserDriver.cdpSend(profile_id, method, params, sessionId, { safe: true });
+    }
+    case "cdp_send_no_safety": {
+      const { profile_id, method, params, sessionId } = CdpSendSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      return await browserDriver.cdpSend(profile_id, method, params, sessionId, { safe: false });
+    }
+    case "evaluate_js": {
+      const { profile_id, expression, sessionId } = EvaluateJsSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      // Runtime.evaluate works without Runtime.enable — no domain is enabled.
+      return await browserDriver.cdpSend(
+        profile_id,
+        "Runtime.evaluate",
+        { expression, returnByValue: true },
+        sessionId,
+        { safe: true },
+      );
+    }
+    case "wait_for_selector": {
+      const { profile_id, selector, timeout_ms, sessionId } = WaitForSelectorSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      const expression = `!!document.querySelector(${JSON.stringify(selector)})`;
+      const found = await pollUntil(
+        async () => {
+          const res = (await browserDriver.cdpSend(
+            profile_id,
+            "Runtime.evaluate",
+            { expression, returnByValue: true },
+            sessionId,
+            { safe: true },
+          )) as { result?: { value?: unknown } };
+          return res?.result?.value === true;
+        },
+        timeout_ms ?? 30000,
+      );
+      return { found, selector };
+    }
+    case "get_cookies": {
+      const { profile_id, urls, sessionId } = GetCookiesSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      // Network.getCookies works without Network.enable.
+      const params = urls ? { urls } : {};
+      return await browserDriver.cdpSend(profile_id, "Network.getCookies", params, sessionId, {
+        safe: true,
+      });
+    }
+    case "set_cookies": {
+      const { profile_id, cookies, sessionId } = SetCookiesSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      // Network.setCookies (plural) sets the whole batch in one call without
+      // Network.enable.
+      return await browserDriver.cdpSend(profile_id, "Network.setCookies", { cookies }, sessionId, {
+        safe: true,
+      });
+    }
+    case "list_tabs": {
+      const { profile_id, sessionId } = ListTabsSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      return await browserDriver.cdpSend(profile_id, "Target.getTargets", {}, sessionId, {
+        safe: true,
+      });
+    }
+    case "new_tab": {
+      const { profile_id, url, sessionId } = NewTabSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      return await browserDriver.cdpSend(
+        profile_id,
+        "Target.createTarget",
+        { url: url ?? "about:blank" },
+        sessionId,
+        { safe: true },
+      );
+    }
+    case "activate_tab": {
+      const { profile_id, target_id, sessionId } = TabIdSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      return await browserDriver.cdpSend(
+        profile_id,
+        "Target.activateTarget",
+        { targetId: target_id },
+        sessionId,
+        { safe: true },
+      );
+    }
+    case "close_tab": {
+      const { profile_id, target_id, sessionId } = TabIdSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      return await browserDriver.cdpSend(
+        profile_id,
+        "Target.closeTarget",
+        { targetId: target_id },
+        sessionId,
+        { safe: true },
+      );
+    }
+    case "wait_for_navigation":
+    case "wait_for_load": {
+      const { profile_id, timeout_ms, sessionId } = WaitForLoadSchema.parse(args);
+      assertProfileRunning(browserDriver, profile_id);
+      // `Page` is enabled at connect, but waiting on the loadEventFired event
+      // requires an event subscription the single cdpSend primitive can't
+      // express. Polling document.readyState gives the same readiness signal
+      // purely through Runtime.evaluate (no domain enable).
+      const loaded = await pollUntil(
+        async () => {
+          const res = (await browserDriver.cdpSend(
+            profile_id,
+            "Runtime.evaluate",
+            { expression: "document.readyState", returnByValue: true },
+            sessionId,
+            { safe: true },
+          )) as { result?: { value?: unknown } };
+          return res?.result?.value === "complete";
+        },
+        timeout_ms ?? 30000,
+      );
+      return { loaded };
+    }
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
 }
+
+const PROXY_JSON_SCHEMA = {
+  type: "object",
+  description: "Per-profile proxy. DNS is resolved remotely via a local SOCKS5 bridge.",
+  required: ["type", "host", "port"],
+  properties: {
+    type: { type: "string", enum: ["http", "socks5"] },
+    host: { type: "string" },
+    port: { type: "integer", minimum: 1, maximum: 65535 },
+    username: { type: "string" },
+    password: { type: "string" },
+  },
+} as const;
+
+const FINGERPRINT_JSON_SCHEMA = {
+  type: "object",
+  description:
+    "High-level fingerprint dimensions. The server derives a coherent UA / Client-Hints / WebGL / locale story from these — raw surfaces cannot be set individually. All fields optional; omitted ones keep their current/coherent value.",
+  properties: {
+    device: {
+      type: "string",
+      enum: [...DEVICE_FAMILIES],
+      description: "Device family to impersonate (see list_fingerprint_options).",
+    },
+    localeId: {
+      type: "string",
+      description: "Locale group id, e.g. 'en-US', 'de-DE' (see list_fingerprint_options).",
+    },
+    timezone: {
+      type: "string",
+      description: "IANA timezone; must belong to the chosen locale, else snapped to a valid one.",
+    },
+    screen: {
+      type: "object",
+      required: ["width", "height"],
+      properties: {
+        width: { type: "integer", minimum: 1 },
+        height: { type: "integer", minimum: 1 },
+      },
+    },
+    hardwareConcurrency: { type: "integer", minimum: 1 },
+    deviceMemory: { type: "number", minimum: 1 },
+  },
+} as const;
 
 const TOOL_DEFINITIONS = [
   {
@@ -189,7 +538,8 @@ const TOOL_DEFINITIONS = [
   },
   {
     name: "create_profile",
-    description: "Create a new browser profile with sensible default fingerprint.",
+    description:
+      "Create a new browser profile. Only `name` is required; a coherent default fingerprint is generated. Optionally pass a `proxy` and/or high-level `fingerprint` knobs to set them at creation time. Call list_fingerprint_options for valid device families and locale ids.",
     inputSchema: {
       type: "object",
       required: ["name"],
@@ -197,6 +547,8 @@ const TOOL_DEFINITIONS = [
         name: { type: "string", description: "Human-readable name" },
         notes: { type: "string" },
         tags: { type: "array", items: { type: "string" } },
+        proxy: PROXY_JSON_SCHEMA,
+        fingerprint: FINGERPRINT_JSON_SCHEMA,
       },
     },
   },
@@ -281,7 +633,237 @@ const TOOL_DEFINITIONS = [
       properties: { profile_id: { type: "string" } },
     },
   },
+  {
+    name: "update_profile",
+    description:
+      "Update an existing profile's name, notes, tags, proxy, and/or fingerprint. Every field is optional — only the ones you pass change. Set `proxy` to null to remove the proxy. Fingerprint changes are reconciled for coherence. If the profile is running, changes apply on the next launch (response includes appliesOnNextLaunch).",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: {
+        profile_id: { type: "string" },
+        name: { type: "string" },
+        notes: { type: "string" },
+        tags: { type: "array", items: { type: "string" } },
+        proxy: {
+          description: "Proxy object to set, or null to clear. Omit to leave unchanged.",
+          anyOf: [PROXY_JSON_SCHEMA, { type: "null" }],
+        },
+        fingerprint: FINGERPRINT_JSON_SCHEMA,
+      },
+    },
+  },
+  {
+    name: "delete_profile",
+    description:
+      "Permanently delete a profile and its on-disk data (cookies, Chromium state, installed extensions). Closes the browser first if it's running. This cannot be undone.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: { profile_id: { type: "string" } },
+    },
+  },
+  {
+    name: "list_fingerprint_options",
+    description:
+      "List the valid fingerprint building blocks: device families (with their real screen sizes) and locale groups (locale, country, plausible timezones). Use these values for the `device`, `localeId`, `timezone`, and `screen` fields of create_profile / update_profile.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "cdp_send",
+    description:
+      "Send a raw Chrome DevTools Protocol command (stealth-safe). Any domain this call had to enable is auto-disabled afterwards so the anti-detect baseline is preserved; domains enabled at connect (Page) are never touched. On anti-detect engines, enabling a DCHECK-sensitive domain (Runtime/Network) is refused — use the convenience wrappers (evaluate_js, get_cookies, …) which need no enable, or cdp_send_no_safety if you accept the risk.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "method"],
+      properties: {
+        profile_id: { type: "string" },
+        method: { type: "string", description: "CDP method, e.g. 'Runtime.evaluate'" },
+        params: { type: "object", description: "CDP command params" },
+        sessionId: { type: "string", description: "Optional flattened CDP sessionId for a sub-target" },
+      },
+    },
+  },
+  {
+    name: "cdp_send_no_safety",
+    description:
+      "Send a raw CDP command with NO safety. WARNING: this bypasses MultiZen's stealth protection — it performs no auto-disable, so any domain you enable (Runtime, Network, DOM, …) stays globally enabled and becomes a detectable automation signal. On anti-detect Chromium builds (CloakBrowser) enabling such domains can trip a DCHECK and crash/expose the session. Only use when you knowingly accept the detection/stability risk.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "method"],
+      properties: {
+        profile_id: { type: "string" },
+        method: { type: "string", description: "CDP method, e.g. 'Network.enable'" },
+        params: { type: "object", description: "CDP command params" },
+        sessionId: { type: "string", description: "Optional flattened CDP sessionId for a sub-target" },
+      },
+    },
+  },
+  {
+    name: "evaluate_js",
+    description:
+      "Evaluate a JavaScript expression in the page and return the result by value. Runs via Runtime.evaluate without enabling the Runtime domain (stealth-safe).",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "expression"],
+      properties: {
+        profile_id: { type: "string" },
+        expression: { type: "string", description: "JavaScript expression to evaluate" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "wait_for_selector",
+    description:
+      "Poll the page until an element matching the CSS selector exists, or the timeout elapses. Returns { found, selector }. Uses Runtime.evaluate polling (no domain enable).",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "selector"],
+      properties: {
+        profile_id: { type: "string" },
+        selector: { type: "string", description: "CSS selector to wait for" },
+        timeout_ms: { type: "integer", minimum: 1, description: "Wait budget in ms (default 30000)" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "get_cookies",
+    description:
+      "Get cookies via Network.getCookies (no Network.enable needed). Optionally restrict to specific URLs.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: {
+        profile_id: { type: "string" },
+        urls: { type: "array", items: { type: "string" }, description: "Optional URL filter" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "set_cookies",
+    description:
+      "Set one or more cookies via Network.setCookies (no Network.enable needed). Each cookie needs at least name and value; CDP fields like url, domain, path, expires, httpOnly, secure, sameSite are also accepted.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "cookies"],
+      properties: {
+        profile_id: { type: "string" },
+        cookies: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["name", "value"],
+            properties: {
+              name: { type: "string" },
+              value: { type: "string" },
+              url: { type: "string" },
+              domain: { type: "string" },
+              path: { type: "string" },
+            },
+          },
+        },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "list_tabs",
+    description: "List open targets (tabs/pages) via Target.getTargets.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: { profile_id: { type: "string" }, sessionId: { type: "string" } },
+    },
+  },
+  {
+    name: "new_tab",
+    description: "Open a new tab via Target.createTarget. Defaults to about:blank if no url is given.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: {
+        profile_id: { type: "string" },
+        url: { type: "string", description: "URL to open (default about:blank)" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "activate_tab",
+    description: "Bring a tab to the foreground via Target.activateTarget.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "target_id"],
+      properties: {
+        profile_id: { type: "string" },
+        target_id: { type: "string", description: "Target id from list_tabs" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "close_tab",
+    description: "Close a tab via Target.closeTarget.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id", "target_id"],
+      properties: {
+        profile_id: { type: "string" },
+        target_id: { type: "string", description: "Target id from list_tabs" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "wait_for_navigation",
+    description:
+      "Wait until the page finishes loading (document.readyState === 'complete'), or the timeout elapses. Returns { loaded }. Polls via Runtime.evaluate (no domain enable).",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: {
+        profile_id: { type: "string" },
+        timeout_ms: { type: "integer", minimum: 1, description: "Wait budget in ms (default 30000)" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "wait_for_load",
+    description:
+      "Alias of wait_for_navigation: wait until document.readyState === 'complete' or the timeout elapses. Returns { loaded }.",
+    inputSchema: {
+      type: "object",
+      required: ["profile_id"],
+      properties: {
+        profile_id: { type: "string" },
+        timeout_ms: { type: "integer", minimum: 1, description: "Wait budget in ms (default 30000)" },
+        sessionId: { type: "string" },
+      },
+    },
+  },
 ];
+
+/** Trim a full FingerprintConfig down to the human-meaningful dimensions
+ *  the caller can actually reason about / set. */
+function fingerprintSummary(fp: FingerprintConfig): {
+  device: string;
+  locale: string;
+  timezone: string;
+  screen: { width: number; height: number };
+  userAgent: string;
+} {
+  return {
+    device: fp.device,
+    locale: fp.locale,
+    timezone: fp.timezone,
+    screen: fp.screen,
+    userAgent: fp.userAgent,
+  };
+}
 
 function summarize(result: unknown): string {
   if (typeof result === "string") return result.slice(0, 200);
@@ -318,5 +900,59 @@ function assertProfileExists(pm: ProfileManager, id: string): void {
 function assertProfileRunning(driver: BrowserDriver, id: string): void {
   if (!driver.isRunning(id)) {
     throw new Error(`Profile ${id} is not running. Call launch_profile first.`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Transient CDP failures raised while a target is mid-navigation: the V8
+ * execution context is torn down and recreated, so an in-flight Runtime.evaluate
+ * can reject even though the page is perfectly fine a moment later. These are
+ * safe to swallow and retry; any other error is a genuine failure (e.g. an
+ * invalid selector expression) and must surface immediately.
+ */
+const TRANSIENT_NAVIGATION_ERROR =
+  /execution context was destroyed|Cannot find context|Inspected target (navigated|closed)|No execution context/i;
+
+function isTransientNavigationError(e: unknown): boolean {
+  const message = e instanceof Error ? e.message : String(e);
+  return TRANSIENT_NAVIGATION_ERROR.test(message);
+}
+
+/**
+ * Poll `check` on a fixed 150ms backoff until it returns true or the budget is
+ * exhausted. Returns the final boolean rather than throwing so wait_* tools
+ * can report a clean `{ found/loaded: false }` on a normal timeout.
+ *
+ * Scoped retry: transient navigation errors (execution context destroyed while
+ * the page reloads) are swallowed and retried until the budget runs out — never
+ * masking real errors, which propagate immediately. If only transient errors
+ * are seen right up to the deadline, a clear timeout error is thrown so the
+ * caller is not told the page settled when it never did.
+ */
+async function pollUntil(check: () => Promise<boolean>, budgetMs: number): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  let lastTransient: Error | undefined;
+  for (;;) {
+    try {
+      if (await check()) return true;
+      lastTransient = undefined; // a clean check ran: not stuck on a transient error
+    } catch (e) {
+      if (!isTransientNavigationError(e)) throw e;
+      lastTransient = e instanceof Error ? e : new Error(String(e));
+    }
+    if (Date.now() >= deadline) {
+      if (lastTransient) {
+        throw new Error(
+          `Timed out after ${budgetMs}ms waiting for the page to settle; ` +
+            `last transient navigation error: ${lastTransient.message}`,
+        );
+      }
+      return false;
+    }
+    await sleep(150);
   }
 }


### PR DESCRIPTION
## Summary

Adds an **additive** MCP tool surface on top of the existing browser-drive tools — no changes to the current tools, transport, or engine behavior.

### CDP access
- **`cdp_send`** — run any CDP command with a safety layer that auto-disables only the domains it had to enable, preserving the stealth baseline. On anti-detect (CloakBrowser) engines it refuses automation-revealing `Runtime.enable` / `Network.enable` (which trip a DCHECK at enable time).
- **`cdp_send_no_safety`** — raw passthrough for when you knowingly need it.
- Convenience tools composed on `cdp_send`: `evaluate_js`, `wait_for_selector`, `get_cookies` / `set_cookies`, `list_tabs` / `new_tab` / `activate_tab` / `close_tab`, `wait_for_navigation`, `wait_for_load`.

### Profile CRUD over MCP
- **`create_profile`**, **`update_profile`**, **`delete_profile`** — take an optional proxy + high-level fingerprint knobs (device / locale / timezone / screen); `reconcileFingerprint` derives a coherent config. Proxy credentials are redacted from the activity log.
- **`list_fingerprint_options`** — enumerates valid device families and locale groups so a caller knows what `create_profile` accepts.

### Supporting changes
- `CdpSession` gains the safe `cdpSend` layer (explicit enable→disable allowlist; refuses risky enables on anti-detect engines) and an `engine` option.
- `ChromiumBrowserDriver` implements `cdpSend` and now waits for **staged CDP readiness** (`/json/version` → a page target exists → `connect`) within one budget before `launch()` resolves — so an MCP `navigate`/`extract` right after launch can't race a not-yet-ready endpoint. This replaces the previous single-stage `waitForCdpReady`.
- `MockBrowserDriver` implements `cdpSend` for protocol tests.

## Test plan
- `yarn typecheck` — clean across all workspaces.
- New tests, all passing via `yarn workspace … run test`:
  - `@multizen/mcp-server` — `cdpTools` (23)
  - `@multizen/cdp-driver` — `CdpSession` (15)
  - `@multizen/desktop` — `cdpReadiness` (5)

---

Extracted from our fork [`kiserufetch/multizen-browser-extended`](https://github.com/kiserufetch/multizen-browser-extended). It intentionally **excludes** fork-specific changes (custom HTTP-transport rewrite, process-tree kill, UI, CI/release tooling) to keep this contribution focused on the MCP tool surface. Happy to adjust scope or split further if you'd prefer.
