### PR TITLE
fix(linux): preserve desktop session when launching Chromium

### DIFF
--- a/apps/desktop/src/main/ChromiumBrowserDriver.ts
+++ b/apps/desktop/src/main/ChromiumBrowserDriver.ts
@@ -411,6 +411,25 @@ export class ChromiumBrowserDriver extends EventEmitter implements BrowserDriver
       // macOS app bundles need this to find their frameworks.
       DYLD_FALLBACK_FRAMEWORK_PATH: process.env.DYLD_FALLBACK_FRAMEWORK_PATH ?? "",
     };
+
+    // Linux GUI clients must inherit the active desktop session. Without
+    // these values a headful Chromium process cannot connect to X11/Wayland
+    // even though the Electron host window is already running successfully.
+    if (process.platform === "linux") {
+      for (const key of [
+        "DISPLAY",
+        "WAYLAND_DISPLAY",
+        "XAUTHORITY",
+        "XDG_RUNTIME_DIR",
+        "XDG_SESSION_TYPE",
+        "XDG_CURRENT_DESKTOP",
+        "DESKTOP_SESSION",
+        "DBUS_SESSION_BUS_ADDRESS",
+      ]) {
+        const value = process.env[key];
+        if (value !== undefined) cleanEnv[key] = value;
+      }
+    }
     // Start page (positional URL) — only on first run, i.e. when there is no
     // restorable session. With `--restore-last-session` a returning profile
     // reopens its real tabs, so we must NOT stack an extra tab; on first launch


### PR DESCRIPTION
## Summary

I ran into this while testing the `v0.3.0` Linux AppImage on a normal graphical desktop session.

The MultiZen application window opened and worked normally, but launching any browser profile failed immediately. The important distinction is that **Electron itself was healthy**; only the managed Chromium child process could not start.

This PR preserves the Linux desktop-session variables required by a headful Chromium process while keeping the existing restricted child environment intact.

## User-visible behavior

1. Start the MultiZen Linux AppImage.
2. The MultiZen interface opens normally.
3. Create or select a profile.
4. Click to launch the profile.
5. No Chromium window appears, and the child process exits with code `1`.

The captured Chromium output included:

```text
ERROR:ui/ozone/platform/x11/ozone_platform_x11.cc:256] Missing X server or $DISPLAY
ERROR:ui/aura/env.cc:246] The platform failed to initialize. Exiting.
[multizen] Chromium pid <pid> exited code=1 signal=—
```

This can be misleading because the desktop application is already visible. It looks like the graphical environment is fine—and it is, for Electron—but the Chromium process is launched with a different, intentionally sanitized environment.

## Root cause

`ChromiumBrowserDriver` builds a minimal environment before calling `spawn()`.

That behavior is intentional and should remain: passing Electron's entire environment to stealth-oriented Chromium builds can leak `ELECTRON_*`, `CHROME_*`, `V8_*`, and other host-specific values that the browser should not inherit.

However, the allowlist only preserved generic POSIX values such as `PATH`, `HOME`, `USER`, locale, and temporary-directory settings. It also preserved the macOS framework lookup path, but it did not preserve the equivalent Linux desktop-session context.

As a result, the Electron process inherited the user's graphical session and opened successfully, while the Chromium child received neither the X11 nor Wayland connection details.

## Why this is not machine-specific

The missing values were removed by application code, not by the operating system or AppImage runtime.

Every Linux profile launch passes through this same environment replacement. A visible Chromium window must be able to connect to either:

- X11/XWayland through `DISPLAY` and, when applicable, `XAUTHORITY`; or
- native Wayland through `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR`.

Because neither path was preserved, the failure can affect Linux users regardless of whether their desktop session is based on X11 or Wayland. Desktop-specific differences may change the exact Ozone error, but not the underlying cause.

## Fix

On Linux only, copy a small explicit allowlist of desktop-session values into the already-sanitized child environment:

- `DISPLAY`
- `WAYLAND_DISPLAY`
- `XAUTHORITY`
- `XDG_RUNTIME_DIR`
- `XDG_SESSION_TYPE`
- `XDG_CURRENT_DESKTOP`
- `DESKTOP_SESSION`
- `DBUS_SESSION_BUS_ADDRESS`

Values are copied only when they exist.

The fix deliberately does **not** merge `process.env` wholesale, and it does not weaken the Chromium sandbox. macOS and Windows behavior remain unchanged.

## Why these values

- `DISPLAY`: X11/XWayland display endpoint.
- `WAYLAND_DISPLAY`: Wayland socket name.
- `XAUTHORITY`: X11 authentication data when required by the session.
- `XDG_RUNTIME_DIR`: location of per-user Wayland and session sockets.
- `XDG_SESSION_TYPE`: communicates whether the session is X11 or Wayland.
- `XDG_CURRENT_DESKTOP` / `DESKTOP_SESSION`: desktop integration context.
- `DBUS_SESSION_BUS_ADDRESS`: access to the user's desktop-session D-Bus services.

## Validation

Tested end-to-end on:

- Pop!_OS 24.04 LTS
- COSMIC desktop
- Wayland session with XWayland available
- x86_64
- MultiZen `v0.3.0` Linux AppImage
- CloakBrowser `146.0.7680.177.5`

Before the fix:

- MultiZen UI opened.
- Profile launch produced the errors shown above.
- Chromium exited with code `1`.
- No CDP endpoint remained available.

After the fix:

- MultiZen UI opened as before.
- The same existing profile launched a visible Chromium window.
- The Chromium process remained alive.
- DevTools reported a listening endpoint on `127.0.0.1`.
- `/json/version` returned the running Chromium version successfully.
- No `Missing X server or $DISPLAY` or platform-initialization error was emitted.

Quality checks:

- `npm run typecheck`
- `npm run lint`
- `npm run build`

All passed locally.

## Scope

This is intentionally a one-file fix in `ChromiumBrowserDriver.ts`. It does not change profile behavior, fingerprinting, proxy handling, packaging, UI code, or browser sandbox settings.
